### PR TITLE
Add MPI build matrix to v2.0.3

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,8 +10,16 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      linux_:
-        CONFIG: linux_
+      linux_mpimpich:
+        CONFIG: linux_mpimpich
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_mpinompi:
+        CONFIG: linux_mpinompi
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_mpiopenmpi:
+        CONFIG: linux_mpiopenmpi
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -10,8 +10,14 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
-      osx_:
-        CONFIG: osx_
+      osx_mpimpich:
+        CONFIG: osx_mpimpich
+        UPLOAD_PACKAGES: True
+      osx_mpinompi:
+        CONFIG: osx_mpinompi
+        UPLOAD_PACKAGES: True
+      osx_mpiopenmpi:
+        CONFIG: osx_mpiopenmpi
         UPLOAD_PACKAGES: True
 
   steps:

--- a/.ci_support/linux_mpimpich.yaml
+++ b/.ci_support/linux_mpimpich.yaml
@@ -1,0 +1,27 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+hdf5:
+- 1.10.5
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8.0 *netlib
+libnetcdf:
+- 4.7.1
+mpi:
+- mpich
+pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x

--- a/.ci_support/linux_mpinompi.yaml
+++ b/.ci_support/linux_mpinompi.yaml
@@ -1,0 +1,27 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+hdf5:
+- 1.10.5
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8.0 *netlib
+libnetcdf:
+- 4.7.1
+mpi:
+- nompi
+pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x

--- a/.ci_support/linux_mpiopenmpi.yaml
+++ b/.ci_support/linux_mpiopenmpi.yaml
@@ -1,17 +1,17 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '9'
+- '7'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '9'
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
 hdf5:
 - 1.10.5
 libblas:
@@ -20,10 +20,8 @@ liblapack:
 - 3.8.0 *netlib
 libnetcdf:
 - 4.7.1
-macos_machine:
-- x86_64-apple-darwin13.4.0
-macos_min_version:
-- '10.9'
+mpi:
+- openmpi
 pin_run_as_build:
   libnetcdf:
     max_pin: x.x.x

--- a/.ci_support/osx_mpimpich.yaml
+++ b/.ci_support/osx_mpimpich.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
+hdf5:
+- 1.10.5
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8.0 *netlib
+libnetcdf:
+- 4.7.1
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- mpich
+pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x

--- a/.ci_support/osx_mpinompi.yaml
+++ b/.ci_support/osx_mpinompi.yaml
@@ -1,17 +1,17 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7'
+- '9'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- '9'
 hdf5:
 - 1.10.5
 libblas:
@@ -20,6 +20,12 @@ liblapack:
 - 3.8.0 *netlib
 libnetcdf:
 - 4.7.1
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- nompi
 pin_run_as_build:
   libnetcdf:
     max_pin: x.x.x

--- a/.ci_support/osx_mpiopenmpi.yaml
+++ b/.ci_support/osx_mpiopenmpi.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+c_compiler:
+- clang
+c_compiler_version:
+- '9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
+hdf5:
+- 1.10.5
+libblas:
+- 3.8 *netlib
+liblapack:
+- 3.8.0 *netlib
+libnetcdf:
+- 4.7.1
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+mpi:
+- openmpi
+pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -43,17 +43,45 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux</td>
+              <td>linux_mpimpich</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6527&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tempest-remap-feedstock?branchName=master&jobName=linux&configuration=linux_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tempest-remap-feedstock?branchName=master&jobName=linux&configuration=linux_mpimpich" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx</td>
+              <td>linux_mpinompi</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6527&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tempest-remap-feedstock?branchName=master&jobName=osx&configuration=osx_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tempest-remap-feedstock?branchName=master&jobName=linux&configuration=linux_mpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_mpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6527&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tempest-remap-feedstock?branchName=master&jobName=linux&configuration=linux_mpiopenmpi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_mpimpich</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6527&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tempest-remap-feedstock?branchName=master&jobName=osx&configuration=osx_mpimpich" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_mpinompi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6527&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tempest-remap-feedstock?branchName=master&jobName=osx&configuration=osx_mpinompi" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_mpiopenmpi</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6527&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tempest-remap-feedstock?branchName=master&jobName=osx&configuration=osx_mpiopenmpi" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,11 @@
 set -x
 set -e
 
+if [[ -n "$mpi" && "$mpi" != "nompi" ]]; then
+  export CC=mpicc
+  export CXX=mpicxx
+fi
+
 # Attempting to fix:
 #   dyld: lazy symbol binding failed: Symbol not found: _nc__create
 #     Referenced from: .../lib/libTempestRemap.0.dylib

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,8 @@
+mpi:
+  - nompi
+  - mpich
+  - openmpi
+
+pin_run_as_build:
+  mpich: x.x
+  openmpi: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,13 @@
 {% set name = "tempest-remap" %}
 {% set version = "2.0.3" %}
+{% set build = 4 %}
+
+# recipe-lint fails if mpi is undefined
+{% set mpi = mpi or 'nompi' %}
+{% if mpi == "nompi" %}
+# prioritize nompi via build number
+{% set build = build + 100 %}
+{% endif %}
 
 package:
   name: {{ name|lower }}
@@ -10,8 +18,21 @@ source:
   sha256: b4578c2cb101ba091a10dc914e15ac968257f5db27ca78bc9fb5dbd70bce191f
 
 build:
-  number: 3
   skip: True  # [win]
+  number: {{ build }}
+
+  # add build string so packages can depend on
+  # mpi or nompi variants explicitly:
+  # `tempest-remap * mpi_mpich_*` for mpich
+  # `tempest-remap * mpi_*` for any mpi
+  # `tempest-remap * nompi_*` for no mpi
+
+  {% if mpi != 'nompi' %}
+  {% set mpi_prefix = "mpi_" + mpi %}
+  {% else %}
+  {% set mpi_prefix = "nompi" %}
+  {% endif %}
+  string: "{{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}"
 
 requirements:
   build:
@@ -23,13 +44,20 @@ requirements:
   host:
     - libblas
     - liblapack
+    # need to list hdf5, libnetcdf and netcdf-cxx-legacy twice to get version
+    # pinning from conda_build_config and build pinning from {{ mpi_prefix }}
     - hdf5
+    - hdf5 * {{ mpi_prefix }}_*
     - libnetcdf
+    - libnetcdf * {{ mpi_prefix }}_*
+    - netcdf-cxx-legacy
+    - netcdf-cxx-legacy * {{ mpi_prefix }}_*
   run:
     - libblas
     - liblapack
-    - hdf5
-    - libnetcdf
+    - hdf5 * {{ mpi_prefix }}_*
+    - libnetcdf * {{ mpi_prefix }}_*
+    - netcdf-cxx-legacy * {{ mpi_prefix }}_*
 
 test:
   commands:


### PR DESCRIPTION
TempestRemap itself is purely serial so this is overkill in a way, but MOAB brings in TempestRemap and it is necessary for MOAB to use the same versions of the dependencies (hdf5 and libnetcdf) as TempestRemap.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
