### PR TITLE
Explicitly add MPI as a dependency to v2.0.3

### DIFF
--- a/.ci_support/linux_mpimpich.yaml
+++ b/.ci_support/linux_mpimpich.yaml
@@ -22,6 +22,3 @@ libnetcdf:
 - 4.7.3
 mpi:
 - mpich
-pin_run_as_build:
-  libnetcdf:
-    max_pin: x.x.x

--- a/.ci_support/linux_mpinompi.yaml
+++ b/.ci_support/linux_mpinompi.yaml
@@ -22,6 +22,3 @@ libnetcdf:
 - 4.7.3
 mpi:
 - nompi
-pin_run_as_build:
-  libnetcdf:
-    max_pin: x.x.x

--- a/.ci_support/linux_mpiopenmpi.yaml
+++ b/.ci_support/linux_mpiopenmpi.yaml
@@ -22,6 +22,3 @@ libnetcdf:
 - 4.7.3
 mpi:
 - openmpi
-pin_run_as_build:
-  libnetcdf:
-    max_pin: x.x.x

--- a/.ci_support/osx_mpimpich.yaml
+++ b/.ci_support/osx_mpimpich.yaml
@@ -26,6 +26,3 @@ macos_min_version:
 - '10.9'
 mpi:
 - mpich
-pin_run_as_build:
-  libnetcdf:
-    max_pin: x.x.x

--- a/.ci_support/osx_mpinompi.yaml
+++ b/.ci_support/osx_mpinompi.yaml
@@ -26,6 +26,3 @@ macos_min_version:
 - '10.9'
 mpi:
 - nompi
-pin_run_as_build:
-  libnetcdf:
-    max_pin: x.x.x

--- a/.ci_support/osx_mpiopenmpi.yaml
+++ b/.ci_support/osx_mpiopenmpi.yaml
@@ -26,6 +26,3 @@ macos_min_version:
 - '10.9'
 mpi:
 - openmpi
-pin_run_as_build:
-  libnetcdf:
-    max_pin: x.x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tempest-remap" %}
 {% set version = "2.0.3" %}
-{% set build = 5 %}
+{% set build = 6 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
@@ -34,6 +34,11 @@ build:
   {% endif %}
   string: "{{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}"
 
+  {% if mpi != 'nompi' %}
+  run_exports:
+    - {{ name }} * {{ mpi_prefix }}_*
+  {% endif %}
+
 requirements:
   build:
     - autoconf
@@ -42,6 +47,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
+    - {{ mpi }}  # [mpi != 'nompi']
     - libblas
     - liblapack
     # need to list hdf5, libnetcdf and netcdf-cxx-legacy twice to get version
@@ -53,6 +59,7 @@ requirements:
     - netcdf-cxx-legacy
     - netcdf-cxx-legacy * {{ mpi_prefix }}_*
   run:
+    - {{ mpi }}  # [mpi != 'nompi']
     - libblas
     - liblapack
     - hdf5 * {{ mpi_prefix }}_*


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
