### PR TITLE
Remove unneeded depencency on netcdf_cxx_legacy

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tempest-remap" %}
 {% set version = "2.0.3" %}
-{% set build = 6 %}
+{% set build = 7 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
@@ -50,21 +50,18 @@ requirements:
     - {{ mpi }}  # [mpi != 'nompi']
     - libblas
     - liblapack
-    # need to list hdf5, libnetcdf and netcdf-cxx-legacy twice to get version
+    # need to list hdf5 and libnetcdf twice to get version
     # pinning from conda_build_config and build pinning from {{ mpi_prefix }}
     - hdf5
     - hdf5 * {{ mpi_prefix }}_*
     - libnetcdf
     - libnetcdf * {{ mpi_prefix }}_*
-    - netcdf-cxx-legacy
-    - netcdf-cxx-legacy * {{ mpi_prefix }}_*
   run:
     - {{ mpi }}  # [mpi != 'nompi']
     - libblas
     - liblapack
     - hdf5 * {{ mpi_prefix }}_*
     - libnetcdf * {{ mpi_prefix }}_*
-    - netcdf-cxx-legacy * {{ mpi_prefix }}_*
 
 test:
   commands:


### PR DESCRIPTION
This is not needed since 2.0.2

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
